### PR TITLE
Added extra note on testing the detach procedure

### DIFF
--- a/src/detach/detach-11.md
+++ b/src/detach/detach-11.md
@@ -27,6 +27,8 @@ If at any step you run into a problem, you may need to repeat the previous steps
 
 The steps described in this document are not for evaluation purposes and are to be used only if you decide to stop using OutSystems.
 
+Nevertheless, you can follow the steps below if you want to test the OutSystems capabilities of detaching your application's source code by performing the Detach process using a **brand new Application Server** and a **new database**. Doing this will prevent unexpected behaviors with your existing OutSystems applications, since the detach process will require changes to the applicational server (IIS) and your database.
+
 ### What do you need?
 
 You need to fulfill the [system requirements](https://success.outsystems.com/Documentation/11/Setting_Up_OutSystems/OutSystems_system_requirements) and additionally must have Microsoft Build Tools 2019 installed.

--- a/src/detach/detach-11.md
+++ b/src/detach/detach-11.md
@@ -25,9 +25,9 @@ If at any step you run into a problem, you may need to repeat the previous steps
 
 ## Before you start { #before-you-start }
 
-The steps described in this document are not for evaluation purposes and are to be used only if you decide to stop using OutSystems.
+The steps described in this document are to be used only if you decide to stop using OutSystems.
 
-Nevertheless, you can follow the steps below if you want to test the OutSystems capabilities of detaching your application's source code by performing the Detach process using a **brand new Application Server** and a **new database**. Doing this will prevent unexpected behaviors with your existing OutSystems applications, since the detach process will require changes to the applicational server (IIS) and your database.
+Nevertheless, you can follow the steps below if you want to test the OutSystems detach capabilities. In that case, follow the detach process using a **brand new Application Server** and a **new database**. This will prevent unexpected behaviors on your existing OutSystems applications since the detach process will require changes to the applicational server (IIS) and to your database.
 
 ### What do you need?
 


### PR DESCRIPTION
Testing the detach procedure is something that the customers often do and it needs to be performed in a brand new server and database, in order to avoid causing unexpected behaviours with the existing OutSystems applications.