### PR TITLE
Update scheduler configuration location

### DIFF
--- a/src/enterprise/troubleshooting/change-logging-levels.md
+++ b/src/enterprise/troubleshooting/change-logging-levels.md
@@ -36,7 +36,8 @@ These files can be found at `C:\Program Files\OutSystems\Platform Server\`:
 if the file for configuration tool is missing, you may use [this configuration file](https://success.outsystems.com/@api/deki/files/4019/ConfigurationTool.exe.config?revision=1) as example.
 
 Locate the `LogLevel` and `MyListener` lines.
-If they are not present, add the following XML immediately after the `</configSections>` line:
+
+If they are not present, add the following XML immediately after the `</configSections>` or before the `<startup>` lines:
 
 ```
 <system.diagnostics>

--- a/src/enterprise/troubleshooting/change-logging-levels.md
+++ b/src/enterprise/troubleshooting/change-logging-levels.md
@@ -28,14 +28,15 @@ These files can be found at `C:\Program Files\OutSystems\Platform Server\`:
 
 * Log Service: `LogServer.exe.config`
 
-* Scheduler Service: `Scheduler.exe.config`
+* Scheduler Service: `Scheduler.exe.config`, if a \Scheduler\ subfolder exists, change it there instead
 
 * SMS Connector: `SMSConnector.exe.config`
 
 * Configuration Tool:`ConfigurationTool.exe.config`
 if the file for configuration tool is missing, you may use [this configuration file](https://success.outsystems.com/@api/deki/files/4019/ConfigurationTool.exe.config?revision=1) as example.
 
-Add the following XML, immediately after the `</configSections>` line:
+Locate the `LogLevel` and `MyListener` lines.
+If they are not present, add the following XML immediately after the `</configSections>` line:
 
 ```
 <system.diagnostics>
@@ -56,7 +57,7 @@ For example, CompilerService.exe would write to `C:\Program Files\OutSystems\Pla
 
 After editing the log files, you need to restart the service that uses the configuration you've changed.
 
-You can specify a  log level from 0 (less verbose) to 4 (full details). When sending logs to Support team, always use the log level 4 (Errors + Warnings + Info + Debug).
+You can specify a  log level from 0 (less verbose) to 4 (full details) in the `LogLevel` line. When sending logs to Support team, always use the log level 4 (Errors + Warnings + Info + Debug).
 
 ### Java stack
 


### PR DESCRIPTION
At some point in O11 scheduler started being installed inside a subfolder causing the documentation to be outdated.
Added a note to consider both possible locations.

Also made some reviews on the document since the default contents of the services configuration files changed from time to time, making some instructions incorrect.