### PR TITLE
Phase 2 key lifetime

### DIFF
--- a/src/enterprise/troubleshooting/vpn-troubleshooting-guide.md
+++ b/src/enterprise/troubleshooting/vpn-troubleshooting-guide.md
@@ -232,7 +232,7 @@ Check the following VPN settings and ensure that:
 
 1. Encapsulating Security Payload (ESP) protocol 50 isn't blocked (inbound/outbound).
 
-1. The security association lifetime is set to 3600 seconds (60 minutes).
+1. The security association lifetime is equal or lower than 3600 seconds (60 minutes).
 
 1. There are no Firewall ACLs interfering with IPsec traffic.
 


### PR DESCRIPTION
lifetime has a maximum of 3600s, the customers can lower the lifetime on the firewall to be less than 55 minutes. This way customers will always be the ones initiating IPSec SA rekeying.
The trick is to lower the lifetime 
(This problem is really common!)