### PR TITLE
Max VPN Routes

### DIFF
--- a/src/enterprise/maintenance/vpn/vpn-errors.md
+++ b/src/enterprise/maintenance/vpn/vpn-errors.md
@@ -158,7 +158,7 @@ Message
 :   `It is not possible to add <N> routes. The maximum number of routes is <Max> and there are only <N> available.`
 
 Cause
-:   You have reached the maximum of 20 routes for your VPN connections. You can't add more routes.
+:   You have reached the maximum of 25 routes for your VPN connections. You can't add more routes.
 
 Recommendation
 :   Don't use this route, or modify the existing routes to accommodate the required IP range. You can check the existing routes in your LifeTime console, under **Environments > Options > VPN Management**. Alternatively, consider managing the connectivity between your data centers and the OutSystems Cloud [using an AWS Transit Gateway](../connect-tgw.md).


### PR DESCRIPTION
The maximum limit is 25 shared across all VPNs in the network.
![image](https://user-images.githubusercontent.com/87149074/131513490-3b25ef43-fe67-40e5-956d-8797009c856d.png)
