### PR TITLE
docs: R11PIT-586 Update the documentation to reflect required step wh…

### DIFF
--- a/src/enterprise/maintenance/migrate-env-db-clone.md
+++ b/src/enterprise/maintenance/migrate-env-db-clone.md
@@ -196,12 +196,19 @@ To do it:
 
 1. Open a query editor tool, connect to the Platform database and execute the following SQL statement to know the names of the tables to delete the content:
 ```
-select physical_table_name from ossys_entity where name in ('ConfigIdP', 'ConfigSP', 'ConfigInternal', 'ConfigFile', 'ConfigFileBinary', 'Config_UserMappings')
+SELECT physical_table_name
+FROM ossys_entity
+WHERE name in ('ConfigIdP',
+               'ConfigSP',
+               'ConfigInternal',
+               'ConfigFile',
+               'ConfigFileBinary',
+               'Config_UserMappings')
 ```
  
 2. Truncate the content of the above tables
 ```
-truncate table [physical_table_name];
+TRUNCATE TABLE [physical_table_name];
 ```
 
 3. Reset the following Site Properties to their default values:


### PR DESCRIPTION
…en migrating databases

https://outsystemsrd.atlassian.net/browse/RPM-1655

### Symptoms
When a migration is made, part of that process implies using a new private.key.

Because the information of the SAML configuration it's encrypted using the private.key the only solution is to delete the current configuration from the database, reset the authentication settings and configure the SAML again.
The only way he could prevent this is to beforehand know he must go back to the default config. and then perform the operation, which is a very cumbersome process i would dare to say.

### How to reproduce
Perform a migration while following our documentation when the SAML configuration is set.