### PR TITLE
Clarified the server type

### DIFF
--- a/src/enterprise/install/add-certificate-trusted.md
+++ b/src/enterprise/install/add-certificate-trusted.md
@@ -20,7 +20,7 @@ When this step isn't done, errors like ```Could not establish trust relationship
 
 <div class="info" markdown="1">
 
-OutSystems servers must have a valid SSL certificate issued by a public Certificate Authority, as described in [OutSystems system requirements](https://success.outsystems.com/Documentation/11/Setting_Up_OutSystems/OutSystems_system_requirements).
+OutSystems **Production** servers must have a valid SSL certificate issued by a public Certificate Authority, as described in [OutSystems system requirements](https://success.outsystems.com/Documentation/11/Setting_Up_OutSystems/OutSystems_system_requirements).
 </div>
 
 For OutSystems Cloud environments check [this article](https://success.outsystems.com/Support/Enterprise_Customers/Maintenance_and_Operations/Add_certificate_to_trusted_root_store_in_OutSystems_PaaS) instead.


### PR DESCRIPTION
According to the documentation below, self-signed certificates are not supported on Production servers, but can be used on non-Production servers:

https://success.outsystems.com/Support/Enterprise_Customers/Installation/How_to_install_an_SSL_Certificate_in_self-managed_environments