### PR TITLE
Add remark to use a clean server when adding a front-end

### DIFF
--- a/src/enterprise/install/add-front-end/add-front-end.md
+++ b/src/enterprise/install/add-front-end/add-front-end.md
@@ -54,6 +54,10 @@ On the environments you manage, follow a standard server instalation:
         * For all other versions, choose the **Front-end Server** role
     * Select the applicable operating system and database software options
 
+<div class="info" markdown="1">
+Make sure the new server is a clean Platform Server installation and does not contain settings from previous OutSystems installations. Otherwise, a recompilation of all the modules in the factory might be required.
+</div>
+
 ### Use automation to add new front ends
 
 It's possible to automate horizontal scalability using OutSystems unattended installation commands. The complete instructions can be found at [this document](https://success.outsystems.com/Documentation/11/Setting_Up_OutSystems/Unattended_Installation_and_Upgrade#Adding_a_Front-End).


### PR DESCRIPTION
**Context**

During the investigation of https://outsystemsrd.atlassian.net/browse/RPM-951, we discovered that there are situations where servers that contain configurations from previous OutSystems Installations are being added as front-ends in farm scenarios.
This is not supported and might lead to the customers having to republish their entire factories, which is usually a high-impact workaround.

With this change, we want to raise awareness for this behavior, to make sure this doesn't happen often.