### PR TITLE
Update to resolve typo in src/personal/whats-a-personal.md

### DIFF
--- a/src/personal/whats-a-personal.md
+++ b/src/personal/whats-a-personal.md
@@ -12,7 +12,7 @@ We've been working on this article. Please let us know how useful this new versi
 
 The Personal Environment (PE) is the **free, cloud-based version** of OutSystems. It allows you to create, deploy, and run your personal applications.
 
-When you [create an account](https://www.outsystems.com/home/GetStartedForFree.aspx) at the OutSystems community, we'll invite you to create a Personal Environment. Once created, it's address and status will always be accessible at your [Plaform Home](https://www.outsystems.com/home) page.
+When you [create an account](https://www.outsystems.com/home/GetStartedForFree.aspx) at the OutSystems community, we'll invite you to create a Personal Environment. Once created, it's address and status will always be accessible at your [Platform Home](https://www.outsystems.com/home) page.
 
 ## Is it really free? Until when?
 


### PR DESCRIPTION
Found a typo on the second hyperlink in whats-a-personal.md: "**Plaform Home**" to "**Platform Home**"