### PR TITLE
Add note to where the service permissions error page does not apply

### DIFF
--- a/src/enterprise/troubleshooting/service-permissions-change.md
+++ b/src/enterprise/troubleshooting/service-permissions-change.md
@@ -10,7 +10,7 @@ app_type: traditional web apps, mobile apps, reactive web apps
 
 <div class="info" markdown="1">
 
-This article does not apply to OutSystems installations that are using Windows Authentication as the Database Authentication type.
+This article **doesn't apply** to OutSystems installations that use **Windows Authentication** as the Database Authentication type.
 
 </div>
 

--- a/src/enterprise/troubleshooting/service-permissions-change.md
+++ b/src/enterprise/troubleshooting/service-permissions-change.md
@@ -10,7 +10,7 @@ app_type: traditional web apps, mobile apps, reactive web apps
 
 <div class="info" markdown="1">
 
-This article does not apply OutSystems installations that are using Windows Authentication as the Database Authentication type.
+This article does not apply to OutSystems installations that are using Windows Authentication as the Database Authentication type.
 
 </div>
 

--- a/src/enterprise/troubleshooting/service-permissions-change.md
+++ b/src/enterprise/troubleshooting/service-permissions-change.md
@@ -8,6 +8,12 @@ app_type: traditional web apps, mobile apps, reactive web apps
 
 # Service permissions error when installing or upgrading to Platform Server 11.12.0 or later
 
+<div class="info" markdown="1">
+
+This article does not apply OutSystems installations that are using Windows Authentication as the Database Authentication type.
+
+</div>
+
 ## Symptoms
 
 In a self-managed environment, installing or upgrading to Platform Server 11.12.0 or later fails. You see the message: ``Failed to set permissions for OutSystems services.``


### PR DESCRIPTION
Even though the error itself should not appear on these conditions it would be possible to use the information on this page to go after other non related problems regarding permission errors after upgrading or installing a recent version of the platform.

Adding a note making it explicit that no information on the page applies to that scenario.

Note that I prefered to make the sentense on the negative becasue:
-  the other type is called in the UI of ConfigurationTool "Database Authentication". So the sentence would be "when using Database Authentication as Database Authentication type", which is very strange.
- the page does apply to Oracle, and in oracle there is no option to choose a Database Authentication type, since there is only one.