### PR TITLE
Fix release note outsystems-developer-cloud-2025-01-11.htm

### DIFF
--- a/src/release-notes/odc/ga/outsystems-developer-cloud-2025-01-11.htm
+++ b/src/release-notes/odc/ga/outsystems-developer-cloud-2025-01-11.htm
@@ -6,14 +6,3 @@ pageprivacy: public
 <h2 id="outsystems_developer_cloud_2025-01-11" >OutSystems Developer Cloud 2025-01-11</h2>
 <div class="info"><p>Released on Jan 11, 2025</p></div>
 
-
-<style>.cattag {background: #f4f2ff; color: #6a6581; padding: 4px 10px;}</style>
-<h3 id="new_in_outsystems_developer_cloud_2025-01-11" > New</h3>
-<ul>
-<li>...
-
-Guidelines - https://outsystemsrd.atlassian.net/wiki/spaces/RRT/pages/111313011/Guidelines+to+write+Release+Notes#Template (ROU-11440)</li>
-</ul>
-
-</ul>
-


### PR DESCRIPTION
- Removed a release note wrongly caught by an automation the team was unaware of.