### PR TITLE
Update SDK version from 18.0 to 18.1

### DIFF
--- a/src/release-articles/mabs/mabs-versions.md
+++ b/src/release-articles/mabs/mabs-versions.md
@@ -130,7 +130,7 @@ This version can run your apps on:
         <tr>
             <td style="vertical-align:middle;width:156px;">Target SDK</td>
             <td style="width:231px;">15 (API Level 35)<br/></td>
-            <td>18.0<br/></td>
+            <td>18.1<br/></td>
         </tr>
         <tr>
             <td style="vertical-align:middle;width:156px;">Tools</td>


### PR DESCRIPTION
Xcode 16.1 (used on MABS 11.2) uses the iOS SDK 18.1, not 18,0 
https://xcodereleases.com/